### PR TITLE
fix: pass GH_ORG_TOKEN explicitly to gh-teams-sync

### DIFF
--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -13,4 +13,5 @@ jobs:
     permissions:
       contents: read
     uses: actionsforge/actions/.github/workflows/gh-teams-sync.yml@main
-    secrets: inherit
+    secrets:
+      GH_ORG_TOKEN: ${{ secrets.GH_ORG_TOKEN }}


### PR DESCRIPTION
## Summary
- Scheduled sync failed with `Missing GITHUB_TOKEN` because `secrets: inherit` did not pass `GH_ORG_TOKEN` into the cross-org reusable workflow
- Pass `GH_ORG_TOKEN` explicitly (matches [actionsforge/actions#126](https://github.com/actionsforge/actions/pull/126))

## Test plan
- [ ] CI green
- [ ] Re-run GitHub Teams Sync (workflow_dispatch)