### PR TITLE
fix: drop missing platformfuzz/actions from teams.yaml

### DIFF
--- a/teams.yaml
+++ b/teams.yaml
@@ -15,8 +15,6 @@ teams:
       - username: jajera
         role: maintainer
     repositories:
-      - name: actions
-        permission: maintain
       - name: gh-team-sync
         permission: push
       - name: image-builder
@@ -30,8 +28,6 @@ teams:
       - username: jajera
         role: maintainer
     repositories:
-      - name: actions
-        permission: push
       - name: gh-team-sync
         permission: push
       - name: image-builder


### PR DESCRIPTION
## Summary
- After restoring `GH_ORG_TOKEN`, sync failed with 404 on `PUT .../teams/platform/repos/platformfuzz/actions`
- Remove nonexistent `actions` repo entries from `platform` and `devops` teams

## Test plan
- [ ] CI green
- [ ] Re-run GitHub Teams Sync